### PR TITLE
Exception filename contains seconds

### DIFF
--- a/src/Tracy/LoggerHelper.php
+++ b/src/Tracy/LoggerHelper.php
@@ -70,7 +70,7 @@ class LoggerHelper extends \Tracy\Logger
 				return $dir . $file;
 			}
 		}
-		return $dir . 'exception--' . $datetime->format('Y-m-d--H-i') . '--' . $hash . '.html';
+		return $dir . 'exception--' . $datetime->format('Y-m-d--H-i-s') . '--' . $hash . '.html';
 	}
 
 	/**


### PR DESCRIPTION
Current filename lacks seconds which may be a very important piece of information during debugging.