### PR TITLE
Automatically create Tracy logs directory

### DIFF
--- a/src/Tracy/LogDirectoryCouldNotBeCreatedException.php
+++ b/src/Tracy/LogDirectoryCouldNotBeCreatedException.php
@@ -10,7 +10,7 @@
 
 namespace Nella\MonologTracy\Tracy;
 
-class InvalidLogDirectoryException extends \LogicException implements \Nella\MonologTracy\Tracy\Exception
+class LogDirectoryCouldNotBeCreatedException extends \LogicException implements \Nella\MonologTracy\Tracy\Exception
 {
 
 	/** @var string */
@@ -23,7 +23,7 @@ class InvalidLogDirectoryException extends \LogicException implements \Nella\Mon
 	public function __construct($logDirectory, \Exception $previous = NULL)
 	{
 		parent::__construct(sprintf(
-			'Tracy log directory "%s" not found or is not a directory.',
+			'Tracy log directory "%s" could not be created or is not a directory.',
 			$logDirectory
 		), 0, $previous);
 

--- a/src/Tracy/LoggerHelper.php
+++ b/src/Tracy/LoggerHelper.php
@@ -23,14 +23,16 @@ class LoggerHelper extends \Tracy\Logger
 	 */
 	public function __construct($directory, BlueScreen $blueScreen)
 	{
-		$logDirectoryRealPath = realpath($directory);
-		if ($logDirectoryRealPath === FALSE || !is_dir($directory)) {
-			throw new \Nella\MonologTracy\Tracy\InvalidLogDirectoryException(sprintf(
-				'Tracy log directory "%s" not found or is not a directory.',
-				$directory
-			));
+		if (!is_dir($directory)) {
+			if (!@mkdir($directory, 0777, TRUE) && !is_dir($directory)) {
+				throw new \Nella\MonologTracy\Tracy\LogDirectoryCouldNotBeCreatedException(sprintf(
+					'Tracy log Directory "%s" could not be created.',
+					$directory
+				));
+			}
 		}
 
+		$logDirectoryRealPath = realpath($directory);
 		parent::__construct($logDirectoryRealPath, NULL, $blueScreen);
 	}
 

--- a/tests/Tracy/LoggerHelperTest.php
+++ b/tests/Tracy/LoggerHelperTest.php
@@ -51,12 +51,19 @@ class LoggerHelperTest extends \Nella\MonologTracy\TestCase
 		$this->loggerHelper->defaultMailer('Test', 'email@example.com');
 	}
 
-	/**
-	 * @expectedException \Nella\MonologTracy\Tracy\InvalidLogDirectoryException
-	 */
-	public function testInvalidLogDirectory()
+	public function testLogDirectoryCannotBeCreatedIfThereIsFileWithSameName()
 	{
-		$logDirectory = sys_get_temp_dir() . '/' . getmypid() . microtime() . '-LoggerHelperTest';
+		$logDirectoryParent = sys_get_temp_dir() . '/' . getmypid() . microtime() . '-LoggerHelperTest';
+		$logDirectory = $logDirectoryParent . '/logdir';
+
+		mkdir($logDirectoryParent);
+
+		// create a dummy file with the same name as the log directory
+		file_put_contents($logDirectoryParent . '/logdir', 'dummy');
+		$this->assertFileExists($logDirectory);
+
+		$this->expectException(\Nella\MonologTracy\Tracy\LogDirectoryCouldNotBeCreatedException::class);
+
 		new LoggerHelper($logDirectory, new \Tracy\BlueScreen());
 	}
 


### PR DESCRIPTION
This is a changed required for compatibility with Symfony 4 + Flex (where the `/var/` directory is not versioned, so the library should create the required directory itself. 

https://github.com/symfony/recipes-contrib/pull/300