### PR TITLE
use same hashes for file names as Tracy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	"require": {
 		"php": "~7.0",
 		"monolog/monolog": "~1.1",
-		"tracy/tracy": "~2.3.0|~2.4.0"
+		"tracy/tracy": "~2.4.0"
 	},
 	"require-dev": {
 		"jakub-onderka/php-console-highlighter": "0.3.2",

--- a/src/Tracy/LoggerHelper.php
+++ b/src/Tracy/LoggerHelper.php
@@ -52,7 +52,17 @@ class LoggerHelper extends \Tracy\Logger
 	 */
 	public function getExceptionHash($exception)
 	{
-		return substr(md5(preg_replace('~(Resource id #)\d+~', '$1', $exception)), 0, 10);
+		$tracyExceptionFilePath = parent::getExceptionFile($exception);
+		$matches = [];
+		preg_match('~^.*--(?P<hash>[a-fA-F0-9]+).html$~', $tracyExceptionFilePath, $matches);
+		if (!isset($matches['hash'])) {
+			// @codeCoverageIgnoreStart
+			// not testable since it would be eventually coming from parent
+			throw new \Nella\MonologTracy\Tracy\NotSupportedException('Non-compatible exception file name -> unexpected Tracy version.');
+		}
+		// @codeCoverageIgnoreEnd
+
+		return $matches['hash'];
 	}
 
 	/**


### PR DESCRIPTION
When this library was created there was no public API in Tracy to get the resulting filename without generating it first. That is why a copy of this algorithm was here AFAIK.

Since then the original implementation was changed though, so now the produced hashes are incompatible with the ones produced by Tracy.

I was solving the same thing in the `TracyBlueScreenBundle` integration and since I was expecting such an incompatibility, I was using reflection originally to hack around it. Fortunately since Tracy `2.4` this method is public, so it is much better to use it [directly](https://github.com/VasekPurchart/Tracy-Blue-Screen-Bundle/commit/fb9a4d63e98f2fab3c63df77b0629a51fc91991c#diff-1f31ad100b36571f97b5cdeb3bedfe9aR67).

Since here the class is extened and some more functionality and API was added I had to use a workaround, but I still think it is better.

Also I checked the bundle and most of the different API is not used, so this might be room for future improvement in further PRs.

