### PR TITLE
Fix compatibility with Symfony

### DIFF
--- a/src/Tracy/LoggerHelper.php
+++ b/src/Tracy/LoggerHelper.php
@@ -137,14 +137,4 @@ class LoggerHelper extends \Tracy\Logger
 		throw new \Nella\MonologTracy\Tracy\NotSupportedException('LoggerHelper::sendEmail is not supported.');
 	}
 
-	/**
-	 * @deprecated
-	 * @param string $message
-	 * @param string $email
-	 */
-	public function defaultMailer($message, $email)
-	{
-		throw new \Nella\MonologTracy\Tracy\NotSupportedException('LoggerHelper::defaultMailer is not supported.');
-	}
-
 }


### PR DESCRIPTION
Currently I'm getting this error:

```
User Deprecated: The "Tracy\Logger::defaultMailer()" method is considered internal. It may change without further notice. You should not extend it from "Nella\MonologTracy\Tracy\LoggerHelper".
```

it is thrown by Symfony DebugClassLoader [here](https://github.com/symfony/symfony/blob/v4.0.11/src/Symfony/Component/Debug/DebugClassLoader.php#L263).

It is not necessary to override this method. The default implementation internally calls `formatMessage` which will throw an exception anyway.